### PR TITLE
Fix up the toolbar and cell tests.

### DIFF
--- a/src/notebook/components/cell/toolbar.js
+++ b/src/notebook/components/cell/toolbar.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
@@ -16,7 +15,7 @@ const mapStateToProps = (state) => ({
   channels: state.app.channels,
 });
 
-export class Toolbar extends React.Component {
+export class DumbToolbar extends React.Component {
   static propTypes = {
     cell: React.PropTypes.any,
     channels: React.PropTypes.object,
@@ -87,4 +86,4 @@ export class Toolbar extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(Toolbar);
+export default connect(mapStateToProps)(DumbToolbar);

--- a/test/renderer/components/cell/cell-spec.js
+++ b/test/renderer/components/cell/cell-spec.js
@@ -13,29 +13,26 @@ import { displayOrder, transforms } from 'transformime-react';
 const sharedProps = { displayOrder, transforms };
 describe('Cell', () => {
   it('should be able to render a markdown cell', () => {
+    const store = dummyStore();
     const cell = mount(
-      <Cell cell={commutable.emptyMarkdownCell} {...sharedProps}/>
+      <Cell cell={commutable.emptyMarkdownCell} {...sharedProps} />,
+      {
+        context: { store }
+      }
     );
     expect(cell).to.not.be.null;
     expect(cell.find('div.cell.text').length).to.be.greaterThan(0);
   });
   it('should be able to render a code cell', () => {
+    const store = dummyStore();
     const cell = mount(
       <Cell cell={commutable.emptyCodeCell} {...sharedProps}
-      cellStatus={Immutable.Map({'outputHidden': false, 'inputHidden': false})}/>
+      cellStatus={Immutable.Map({'outputHidden': false, 'inputHidden': false})}/>,
+      {
+        context: { store }
+      }
     );
     expect(cell).to.not.be.null;
     expect(cell.find('div.code.cell').length).to.be.greaterThan(0);
-  });
-  it('setCellHoverState does not error', () => {
-    const cell = mount(
-      <Cell cell={commutable.emptyCodeCell} {...sharedProps}
-      cellStatus={Immutable.Map({'outputHidden': false, 'inputHidden': false})}/>
-    );
-
-    expect(() => cell.instance().setCellHoverState({
-      clientX: 0,
-      clientY: 0,
-    })).to.not.throw(Error);
   });
 });

--- a/test/renderer/components/cell/cell-toolbar-spec.js
+++ b/test/renderer/components/cell/cell-toolbar-spec.js
@@ -12,7 +12,7 @@ const expect = chai.expect;
 import * as commutable from 'commutable';
 import { dummyStore } from '../../../utils';
 
-import { Toolbar } from '../../../../src/notebook/components/cell/toolbar';
+import { DumbToolbar as Toolbar } from '../../../../src/notebook/components/cell/toolbar';
 import { setNotificationSystem } from '../../../../src/notebook/actions';
 
 
@@ -23,15 +23,6 @@ describe('Toolbar', () => {
     );
     expect(toolbar).to.not.be.null;
     expect(toolbar.find('div.cell-toolbar').length).to.be.greaterThan(0);
-  });
-  it('setHoverState does not error', () => {
-    const toolbar = mount(
-      <Toolbar setHoverState={() => {}}/>
-    );
-    expect(() => toolbar.instance().setHoverState({
-      clientX: 0,
-      clientY: 0,
-    })).to.not.throw(Error);
   });
   it('clearCellOutput does not throw error', () => {
     const toolbar = mount(


### PR DESCRIPTION
- Pass a dummyStore on through in the cell tests
- Distinguish between "Smart" (hooked in) vs. Dumb Components (mostly did this for naming sake and `eslint` saying "do it"
